### PR TITLE
Refactor dashboards to use shared wrapper

### DIFF
--- a/src/components/AceternityDashboard.tsx
+++ b/src/components/AceternityDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const AceternityDashboard = () => (
-  <div className="bg-black text-white min-h-screen font-sans">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-black text-white min-h-screen font-sans" />
 );
 
 export default AceternityDashboard;

--- a/src/components/BulmaDashboard.tsx
+++ b/src/components/BulmaDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const BulmaDashboard = () => (
-  <div className="dashboard-app-container">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="dashboard-app-container" />
 );
 
 export default BulmaDashboard;

--- a/src/components/BulmaDashboard1.tsx
+++ b/src/components/BulmaDashboard1.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const BulmaDashboard1 = () => (
-  <div className="dashboard-app-container">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="dashboard-app-container" />
 );
 
 export default BulmaDashboard1;

--- a/src/components/ChakraDashboard.tsx
+++ b/src/components/ChakraDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const ChakraDashboard = () => (
-  <div className="bg-gray-900 text-gray-100 min-h-screen flex font-sans">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-gray-900 text-gray-100 min-h-screen flex font-sans" />
 );
 
 export default ChakraDashboard;

--- a/src/components/CultuiDashboard.tsx
+++ b/src/components/CultuiDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const CultuiDashboard = () => (
-  <div className="bg-gray-900 min-h-screen text-white font-sans">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-gray-900 min-h-screen text-white font-sans" />
 );
 
 export default CultuiDashboard;

--- a/src/components/DashboardWrapper.tsx
+++ b/src/components/DashboardWrapper.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import MasterDashboard from './MasterDashboard';
+
+interface DashboardWrapperProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const DashboardWrapper: React.FC<DashboardWrapperProps> = ({ className, style }) => (
+  <div className={className} style={style}>
+    <MasterDashboard />
+  </div>
+);
+
+export default DashboardWrapper;

--- a/src/components/FrankenDashboard.tsx
+++ b/src/components/FrankenDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const FrankenDashboard = () => (
-  <div className="bg-zinc-900 text-zinc-100 min-h-screen font-mono">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-zinc-900 text-zinc-100 min-h-screen font-mono" />
 );
 
 export default FrankenDashboard;

--- a/src/components/NextuiDashboard.tsx
+++ b/src/components/NextuiDashboard.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const NextuiDashboard = () => (
-  <div className="flex flex-col" style={{ backgroundColor: '#0F1011', color: '#ECEDEE', minHeight: '100vh' }}>
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper
+    className="flex flex-col"
+    style={{ backgroundColor: '#0F1011', color: '#ECEDEE', minHeight: '100vh' }}
+  />
 );
 
 export default NextuiDashboard;

--- a/src/components/ParkDashboard.tsx
+++ b/src/components/ParkDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const ParkDashboard = () => (
-  <div className="bg-slate-950 text-slate-50 min-h-screen font-sans">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-slate-950 text-slate-50 min-h-screen font-sans" />
 );
 
 export default ParkDashboard;

--- a/src/components/ReactAriaDashboard.tsx
+++ b/src/components/ReactAriaDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const ReactAriaDashboard = () => (
-  <div className="bg-gray-900 text-white min-h-screen">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-gray-900 text-white min-h-screen" />
 );
 
 export default ReactAriaDashboard;

--- a/src/components/ShadcnDashboard.tsx
+++ b/src/components/ShadcnDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const ShadcnDashboard = () => (
-  <div className="bg-slate-950 text-slate-50 min-h-screen flex">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-slate-950 text-slate-50 min-h-screen flex" />
 );
 
 export default ShadcnDashboard;

--- a/src/components/TremorDashboard.tsx
+++ b/src/components/TremorDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const TremorDashboard = () => (
-  <div className="bg-gray-900 min-h-screen p-6 overflow-auto">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-gray-900 min-h-screen p-6 overflow-auto" />
 );
 
 export default TremorDashboard;

--- a/src/components/VercelDashboard.tsx
+++ b/src/components/VercelDashboard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import MasterDashboard from './MasterDashboard';
+import DashboardWrapper from './DashboardWrapper';
 
 const VercelDashboard = () => (
-  <div className="bg-black min-h-screen text-white font-sans">
-    <MasterDashboard />
-  </div>
+  <DashboardWrapper className="bg-black min-h-screen text-white font-sans" />
 );
 
 export default VercelDashboard;


### PR DESCRIPTION
## Summary
- add `DashboardWrapper` to host `MasterDashboard`
- refactor individual dashboards to use the wrapper
- keep library selection logic in `App.jsx`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684245a2854883229a780a3d954606c1