### PR TITLE
Fix README library name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project showcases popular Tailwind CSS-based UI libraries with interactive 
 - Bulma UI
 - React Aria
 - Tremor UI
-- Varcel UI
+- Vercel UI
 - Cult UI
 - Next UI
 


### PR DESCRIPTION
## Summary
- fix the spelling of **Vercel UI** in the README

## Testing
- `grep -n "Vercel UI" README.md`


------
https://chatgpt.com/codex/tasks/task_e_684279f58fd483229ce2d94630aa07b6