### PR TITLE
Setup GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+        env:
+          DEPLOY_BASE: /${{ github.event.repository.name }}/
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ Select a library name in the header to load its dashboard. The master layout sta
 
 ## License
 MIT
+
+## Deploying to GitHub Pages
+
+You can publish the static build with **GitHub Pages** using the included
+workflow:
+
+1. Push the repository to GitHub and enable "GitHub Pages" in the repository
+   settings. Choose the **GitHub Actions** option as the source.
+2. Every push to the `main` branch will automatically build the site and deploy
+   it to the `gh-pages` environment. The workflow sets the correct base path so
+   the app loads from `https://<user>.github.io/<repo>/`.
+
+The workflow is defined in `.github/workflows/deploy.yml` and requires no
+manual steps once GitHub Pages is enabled.

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: process.env.DEPLOY_BASE || '/',
   plugins: [react()],
 })
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds and deploys `dist` to GitHub Pages
- allow overriding Vite `base` path via `DEPLOY_BASE`
- document how to enable GitHub Pages in repository settings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6843998c7d00832293c080fa0d69507b