### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,11 @@ workflow:
    it to the `gh-pages` environment. The workflow sets the correct base path so
    the app loads from `https://<user>.github.io/<repo>/`.
 
+If the deployed page is blank, double-check that **GitHub Pages** is
+configured to use the GitHub Actions workflow and not a branch build. The
+`vite.config.js` file now sets the base path to `/tailwind-ui-showcase/`,
+ensuring assets load correctly when hosted at
+`https://<user>.github.io/tailwind-ui-showcase/`.
+
 The workflow is defined in `.github/workflows/deploy.yml` and requires no
 manual steps once GitHub Pages is enabled.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// The project deploys to GitHub Pages under the repository name.
+// Setting a static base path avoids issues where the DEPLOY_BASE
+// environment variable might not be available during the build.
+const repository = 'tailwind-ui-showcase'
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: process.env.DEPLOY_BASE || '/',
+  base: `/${repository}/`,
   plugins: [react()],
 })
 


### PR DESCRIPTION
## Summary
- set a static base path in `vite.config.js`
- add notes in README about checking GitHub Pages settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845055a1b848322b430cd034826b680